### PR TITLE
feat: Add drift compensation

### DIFF
--- a/scripts/drift_comp/LaminarFlowVaryComp.jl
+++ b/scripts/drift_comp/LaminarFlowVaryComp.jl
@@ -1,0 +1,80 @@
+using DrWatson
+@time @quickactivate :CollectiveNavigation
+using Pipe: @pipe
+@time using CairoMakie
+
+include("final_figures/theme.jl")
+# Angle Flow Intended
+intend_config = SimulationConfig(
+    num_repeats=50,
+    flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2), # cross flow
+    sensing=Dict("type" => "ranged", "range" => 50.0),
+    heading_perception=Dict("type" => "intended"),
+    terminal_time=5000,
+    χ=0
+);
+parse_config!(intend_config);
+intend_angle_flow_data = run_experiment_flow_angle(
+    intend_config,
+    :angle,
+    angle_values=collect(0:(π/18):(35π/18)),
+    show_log=true
+)
+# intend_df = decompress_data(intend_angle_flow_data; show_progress=false);
+# intend_angle_flow_data = nothing;
+
+# actual_config = intend_config;
+# actual_config.heading_perception["type"] = "actual"
+# actual_angle_flow_data = run_experiment_flow_angle(
+#     actual_config,
+#     :angle,
+#     angle_values=collect(0:(π/18):(35π/18)),
+#     show_log=true
+# )
+
+# actual_df = decompress_data(actual_angle_flow_data; show_progress=false);
+# actual_angle_flow_data = nothing;
+
+# # Stack them together to get a complete dataset
+# df = vcat(intend_df, actual_df)
+# (intend_df, actual_df) = (nothing, nothing)
+
+# perc_type = "intended"
+# int_arrival_times = @pipe df |>
+#                           subset(_, :heading_perception => ByRow(==(perc_type))) |>
+#                           get_arrival_times(_, [:flow_angle, :flow_strength]) |>
+#                           get_centile_arrival(_; centile=50) |>
+#                           make_failures_explicit(_, df, [:flow_angle, :flow_strength])
+# int_arrival_times[!, "heading_perception"] .= "intended"
+# int_arrival_times[!, "heading_perception_code"] .= 1
+# perc_type = "actual"
+# act_arrival_times = @pipe df |>
+#                           subset(_, :heading_perception => ByRow(==(perc_type))) |>
+#                           get_arrival_times(_, [:flow_angle, :flow_strength]) |>
+#                           get_centile_arrival(_; centile=50) |>
+#                           make_failures_explicit(_, df, [:flow_angle, :flow_strength])
+# act_arrival_times[!, "heading_perception"] .= "actual"
+# act_arrival_times[!, "heading_perception_code"] .= 2
+# arrival_times = vcat(int_arrival_times, act_arrival_times)
+# jldsave(datadir("AngleFlow.jld2");arrival_times)
+arrival_times = load(datadir("AngleFlow.jld2"), "arrival_times")
+int_arrival_times = @pipe arrival_times |>
+                          subset(_, :heading_perception => ByRow(==("intended"))) |>
+                          select(_, [:flow_angle, :heading_perception, :arrival_time_mean])
+act_arrival_times = @pipe arrival_times |>
+                          subset(_, :heading_perception => ByRow(==("actual"))) |>
+                          select(_, [:flow_angle, :heading_perception, :arrival_time_mean])
+
+percent_diff = @pipe leftjoin(
+                         int_arrival_times,
+                         act_arrival_times;
+                         on=:flow_angle, makeunique=true) |>
+                     transform(
+                         _,
+                         [:arrival_time_mean, :arrival_time_mean_1] =>
+                             ((x, y) -> (100 .* (x .- y) ./ y)) =>
+                                 :difference
+                     ) |>
+                     select(_, [:flow_angle, :difference])
+
+

--- a/scripts/drift_comp/LaminarFlowVaryComp.jl
+++ b/scripts/drift_comp/LaminarFlowVaryComp.jl
@@ -3,10 +3,10 @@ using DrWatson
 using Pipe: @pipe
 @time using CairoMakie
 
-include("final_figures/theme.jl")
+include("../../notebooks/final_figures/theme.jl")
 # Angle Flow Intended
 intend_config = SimulationConfig(
-    num_repeats=50,
+    num_repeats=20,
     flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2), # cross flow
     sensing=Dict("type" => "ranged", "range" => 50.0),
     heading_perception=Dict("type" => "intended"),
@@ -14,67 +14,100 @@ intend_config = SimulationConfig(
     χ=0
 );
 parse_config!(intend_config);
-intend_angle_flow_data = run_experiment_flow_angle(
+intend_comp_flow_data = run_experiment_flow_comp(
     intend_config,
-    :angle,
-    angle_values=collect(0:(π/18):(35π/18)),
+    :flow, :χ,
+    flow_values=0:0.1:0.5,
+    comp_values=0:0.1:0.5,
     show_log=true
 )
-# intend_df = decompress_data(intend_angle_flow_data; show_progress=false);
-# intend_angle_flow_data = nothing;
+intend_df = decompress_data(intend_comp_flow_data; show_progress=false);
+intend_comp_flow_data = nothing;
 
-# actual_config = intend_config;
-# actual_config.heading_perception["type"] = "actual"
-# actual_angle_flow_data = run_experiment_flow_angle(
-#     actual_config,
-#     :angle,
-#     angle_values=collect(0:(π/18):(35π/18)),
-#     show_log=true
-# )
 
-# actual_df = decompress_data(actual_angle_flow_data; show_progress=false);
-# actual_angle_flow_data = nothing;
+actual_config = intend_config;
+actual_config.heading_perception["type"] = "actual"
+actual_angle_flow_data = run_experiment_flow_comp(
+    actual_config,
+    :flow, :χ,
+    flow_values=0:0.1:0.5,
+    comp_values=0:0.1:0.5,
+    show_log=true
+)
+
+actual_df = decompress_data(actual_angle_flow_data; show_progress=false);
+actual_angle_flow_data = nothing;
 
 # # Stack them together to get a complete dataset
-# df = vcat(intend_df, actual_df)
-# (intend_df, actual_df) = (nothing, nothing)
+df = vcat(intend_df, actual_df)
+(intend_df, actual_df) = (nothing, nothing)
 
-# perc_type = "intended"
-# int_arrival_times = @pipe df |>
-#                           subset(_, :heading_perception => ByRow(==(perc_type))) |>
-#                           get_arrival_times(_, [:flow_angle, :flow_strength]) |>
-#                           get_centile_arrival(_; centile=50) |>
-#                           make_failures_explicit(_, df, [:flow_angle, :flow_strength])
-# int_arrival_times[!, "heading_perception"] .= "intended"
-# int_arrival_times[!, "heading_perception_code"] .= 1
-# perc_type = "actual"
-# act_arrival_times = @pipe df |>
-#                           subset(_, :heading_perception => ByRow(==(perc_type))) |>
-#                           get_arrival_times(_, [:flow_angle, :flow_strength]) |>
-#                           get_centile_arrival(_; centile=50) |>
-#                           make_failures_explicit(_, df, [:flow_angle, :flow_strength])
-# act_arrival_times[!, "heading_perception"] .= "actual"
-# act_arrival_times[!, "heading_perception_code"] .= 2
+perc_type = "intended"
+int_arrival_times = @pipe df |>
+                          subset(_, :heading_perception => ByRow(==(perc_type))) |>
+                          get_arrival_times(_, [:χ, :flow_strength]) |>
+                          get_centile_arrival(_; centile=50) |>
+                          make_failures_explicit(_, df, [:χ, :flow_strength])
+int_arrival_times[!, "heading_perception"] .= "intended"
+int_arrival_times[!, "heading_perception_code"] .= 1
+perc_type = "actual"
+act_arrival_times = @pipe df |>
+                          subset(_, :heading_perception => ByRow(==(perc_type))) |>
+                          get_arrival_times(_, [:χ, :flow_strength]) |>
+                          get_centile_arrival(_; centile=50) |>
+                          make_failures_explicit(_, df, [:χ, :flow_strength])
+act_arrival_times[!, "heading_perception"] .= "actual"
+act_arrival_times[!, "heading_perception_code"] .= 2
 # arrival_times = vcat(int_arrival_times, act_arrival_times)
 # jldsave(datadir("AngleFlow.jld2");arrival_times)
-arrival_times = load(datadir("AngleFlow.jld2"), "arrival_times")
-int_arrival_times = @pipe arrival_times |>
-                          subset(_, :heading_perception => ByRow(==("intended"))) |>
-                          select(_, [:flow_angle, :heading_perception, :arrival_time_mean])
-act_arrival_times = @pipe arrival_times |>
-                          subset(_, :heading_perception => ByRow(==("actual"))) |>
-                          select(_, [:flow_angle, :heading_perception, :arrival_time_mean])
-
-percent_diff = @pipe leftjoin(
-                         int_arrival_times,
-                         act_arrival_times;
-                         on=:flow_angle, makeunique=true) |>
-                     transform(
-                         _,
-                         [:arrival_time_mean, :arrival_time_mean_1] =>
-                             ((x, y) -> (100 .* (x .- y) ./ y)) =>
-                                 :difference
-                     ) |>
-                     select(_, [:flow_angle, :difference])
-
-
+# arrival_times = load(datadir("AngleFlow.jld2"), "arrival_times")
+arrival_times = int_arrival_times
+logged = true
+size_pt = 420 .* (1.2, 1)
+# 
+xlabels = unique(arrival_times[!, :flow_strength])
+ylabels = unique(arrival_times[!, :χ])
+sort!(arrival_times, [:χ, :flow_strength])
+Z = reshape(arrival_times[!, :arrival_time_mean], (length(xlabels), length(ylabels)))
+limits = extrema(skipmissing(Z))
+fig = CairoMakie.Figure(resolution=size_pt)
+ax1 = CairoMakie.Axis(
+    fig[1, 1];
+    xlabel="Flow Strength",
+    ylabel="χ",
+    xticks=(1:length(xlabels), string.(xlabels)),
+    yticks=(1:length(ylabels), string.(ylabels))
+)
+hm = CairoMakie.heatmap!(ax1,
+    1:length(xlabels),
+    1:length(ylabels),
+    logged ? log.(Z) : Z;
+    colormap=cmap("D4"),
+    colorrange=log.(limits))
+normalised = true
+ref_point = @pipe arrival_times |>
+                  subset(
+    _,
+    :χ => ByRow(==(0)),
+    :flow_strength => ByRow(==(0))
+)
+normalZ = Z ./ ref_point[1, :arrival_time_mean]
+normalZ = [ismissing(i) ? 0 : i for i ∈ normalZ]
+labels = string.(normalised ? round.(normalZ, sigdigits=2) : Z)
+text!(
+    labels[:],
+    position=Point.((1:length(xlabels)), (1:length(ylabels))')[:],
+    align=(:center, :baseline),
+    color=:white,
+    fontsize=10
+    # fontsize=normalised ? 20 : 15
+)
+c = Colorbar(
+    fig[1, 2],
+    colormap=cmap("D4"),
+    colorrange=log.(limits),
+    label="Arrival Time",
+    tickformat=xs -> ["$(round(Int64,exp(x)))" for x in xs]
+)
+fig
+save(String(plotsdir("drift_comp", "perc_type=$(perc_type)_heatmap.svg")), fig, pt_per_unit=1)

--- a/scripts/drift_comp/test_existing_sim.jl
+++ b/scripts/drift_comp/test_existing_sim.jl
@@ -10,7 +10,7 @@ intend_config = SimulationConfig(
     num_repeats=3,
     flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2),
     sensing=Dict("type" => "ranged", "range" => 50.0),
-    heading_perception=Dict("type" => "intended"),
+    heading_perception=Dict("type" => "actual"),
     terminal_time=5000,
     χ=0,
 );
@@ -77,7 +77,7 @@ full_comp_config = SimulationConfig(
     sensing=Dict("type" => "ranged", "range" => 50.0),
     heading_perception=Dict("type" => "intended"),
     terminal_time=5000,
-    χ=1.0
+    χ=0.5
 );
 parse_config!(full_comp_config);
 full_comp_angle_flow_data = run_experiment_flow_angle(
@@ -86,7 +86,7 @@ full_comp_angle_flow_data = run_experiment_flow_angle(
     angle_values=collect(0:(π/18):(π/18)),
     show_log=true
 )
-realisation = subset(full_comp_angle_flow_data, :lw_config => ByRow(x -> (x.sensing["range"] .== 50.0) & (x.flow["angle"] == 0.0) & (x.χ == 1.0)));
+realisation = subset(full_comp_angle_flow_data, :lw_config => ByRow(x -> (x.sensing["range"] .== 50.0) & (x.flow["angle"] == 0.0) & (x.χ == 0.5)));
 ideal_config = realisation.lw_config[1];
 ideal_positions = readdlm(joinpath(ideal_config.save_dir, ideal_config.save_name * ".tsv"));
 ideal_positions[ideal_positions.==""] .= 0;
@@ -101,7 +101,7 @@ sample = 1:sample_size
 size_pt = 390 .* (1, 0.75)
 fig = Figure(resolution=size_pt)
 ax1 = CairoMakie.Axis(
-    fig[1, 1]; title=L"$\chi = 1, \kappa_1 = \kappa_2 = 1$, Intended compensating (yellow), Intended (blue)"
+    fig[1, 1]; title="Less Compensating, Some Navigation", subtitle=L"$\chi = 0.5, \kappa_1 = \kappa_2 = 1$, Ideal (yellow), $\chi=0$, Ideal(blue)"
 )
 for i in 1:5:minimum(hcat(length(ideal_y_pos[:, 1]), length(y_pos[:, 1])))
     scatter!(
@@ -138,4 +138,4 @@ hidespines!(ax1)
 ax1.aspect = DataAspect()
 
 fig
-save(String(plotsdir("test", "scatter_traj_intended_χ=1.png")), fig)
+save(String(plotsdir("test", "scatter_traj_intended_χ=0.5.png")), fig)

--- a/scripts/drift_comp/test_existing_sim.jl
+++ b/scripts/drift_comp/test_existing_sim.jl
@@ -1,0 +1,141 @@
+using DrWatson
+using DelimitedFiles
+@time @quickactivate :CollectiveNavigation
+using Pipe: @pipe
+@time using CairoMakie
+
+include("../../notebooks/final_figures/theme.jl")
+## Angle Flow Intended, simulations that worked previously.
+intend_config = SimulationConfig(
+    num_repeats=3,
+    flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2),
+    sensing=Dict("type" => "ranged", "range" => 50.0),
+    heading_perception=Dict("type" => "intended"),
+    terminal_time=5000,
+    χ=0,
+);
+parse_config!(intend_config);
+savename(intend_config)
+intend_angle_flow_data = run_experiment_flow_angle(
+    intend_config,
+    :angle,
+    angle_values=collect(0:(π/18):(π/18)),
+    show_log=true
+)
+"""Adjust compensation parameter """
+full_comp_config = SimulationConfig(
+    num_repeats=3,
+    flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2),
+    sensing=Dict("type" => "ranged", "range" => 50.0),
+    heading_perception=Dict("type" => "ideal"),
+    terminal_time=5000,
+    χ=1
+);
+parse_config!(full_comp_config);
+full_comp_angle_flow_data = run_experiment_flow_angle(
+    full_comp_config,
+    :angle,
+    angle_values=collect(0:(π/18):(π/18)),
+    show_log=true
+)
+# full_comp_df = decompress_data(full_comp_angle_flow_data; show_progress=false);
+# full_comp_angle_flow_data = nothing;
+
+"""Adjust to intended headings """
+intend_comp_config = SimulationConfig(
+    num_repeats=3,
+    flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2),
+    sensing=Dict("type" => "ranged", "range" => 50.0),
+    heading_perception=Dict("type" => "intended"),
+    terminal_time=5000,
+    χ=1
+);
+parse_config!(intend_comp_config);
+intend_comp_angle_flow_data = run_experiment_flow_angle(
+    intend_comp_config,
+    :angle,
+    angle_values=collect(0:(π/18):(π/18)),
+    show_log=true
+)
+# intend_comp_df = decompress_data(intend_comp_angle_flow_data; show_progress=false);
+# intend_comp_angle_flow_data = nothing;
+
+# df = vcat(intend_df, full_comp_df, intend_comp_df)
+# intended_df = decompress_data(intended_data; show_progress=true);
+# Add ideal data as a step two. First aim is to plot just intended headings
+realisation = subset(intend_angle_flow_data, :lw_config => ByRow(x -> (x.sensing["range"] .== 50.0) & (x.flow["angle"] == 0.0) & (x.χ == 0.0)));
+config = realisation.lw_config[1];
+positions = readdlm(joinpath(config.save_dir, config.save_name * ".tsv"));
+positions[positions.==""] .= 0;
+positions = convert.(Float64, positions);
+x_pos = positions[1:2:end, :];
+y_pos = positions[2:2:end, :];
+
+full_comp_config = SimulationConfig(
+    num_repeats=3,
+    flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2),
+    sensing=Dict("type" => "ranged", "range" => 50.0),
+    heading_perception=Dict("type" => "intended"),
+    terminal_time=5000,
+    χ=1.0
+);
+parse_config!(full_comp_config);
+full_comp_angle_flow_data = run_experiment_flow_angle(
+    full_comp_config,
+    :angle,
+    angle_values=collect(0:(π/18):(π/18)),
+    show_log=true
+)
+realisation = subset(full_comp_angle_flow_data, :lw_config => ByRow(x -> (x.sensing["range"] .== 50.0) & (x.flow["angle"] == 0.0) & (x.χ == 1.0)));
+ideal_config = realisation.lw_config[1];
+ideal_positions = readdlm(joinpath(ideal_config.save_dir, ideal_config.save_name * ".tsv"));
+ideal_positions[ideal_positions.==""] .= 0;
+ideal_positions = convert.(Float64, ideal_positions);
+ideal_x_pos = ideal_positions[1:2:end, :];
+ideal_y_pos = ideal_positions[2:2:end, :];
+
+
+# Scatter agents
+sample_size = 50
+sample = 1:sample_size
+size_pt = 390 .* (1, 0.75)
+fig = Figure(resolution=size_pt)
+ax1 = CairoMakie.Axis(
+    fig[1, 1]; title=L"$\chi = 1, \kappa_1 = \kappa_2 = 1$, Intended compensating (yellow), Intended (blue)"
+)
+for i in 1:5:minimum(hcat(length(ideal_y_pos[:, 1]), length(y_pos[:, 1])))
+    scatter!(
+        ax1,
+        x_pos[i, sample],
+        y_pos[i, sample];
+        markersize=1,
+        color=intended_color
+    )
+    scatter!(
+        ax1,
+        ideal_x_pos[i, sample],
+        ideal_y_pos[i, sample];
+        markersize=1,
+        color=actual_color
+    )
+end
+for i in 5:-2:1
+    scatter!(
+        (0, 0);
+        markersize=5 * (i + 1),
+        color=:white,
+        markerspace=:data
+    )
+    scatter!(
+        (0, 0);
+        markersize=5 * i,
+        color=(:red, 0.8),
+        markerspace=:data
+    )
+end
+hidedecorations!(ax1)
+hidespines!(ax1)
+ax1.aspect = DataAspect()
+
+fig
+save(String(plotsdir("test", "scatter_traj_intended_χ=1.png")), fig)

--- a/scripts/drift_comp/test_existing_sim.jl
+++ b/scripts/drift_comp/test_existing_sim.jl
@@ -46,7 +46,7 @@ intend_comp_config = SimulationConfig(
     num_repeats=3,
     flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2),
     sensing=Dict("type" => "ranged", "range" => 50.0),
-    heading_perception=Dict("type" => "intended"),
+    heading_perception=Dict("type" => "ideal"),
     terminal_time=5000,
     χ=1
 );
@@ -75,9 +75,9 @@ full_comp_config = SimulationConfig(
     num_repeats=3,
     flow=Dict("type" => "angle", "strength" => 0.2, "angle" => π / 2),
     sensing=Dict("type" => "ranged", "range" => 50.0),
-    heading_perception=Dict("type" => "intended"),
+    heading_perception=Dict("type" => "actual"),
     terminal_time=5000,
-    χ=0.5
+    χ=0.2
 );
 parse_config!(full_comp_config);
 full_comp_angle_flow_data = run_experiment_flow_angle(
@@ -86,7 +86,7 @@ full_comp_angle_flow_data = run_experiment_flow_angle(
     angle_values=collect(0:(π/18):(π/18)),
     show_log=true
 )
-realisation = subset(full_comp_angle_flow_data, :lw_config => ByRow(x -> (x.sensing["range"] .== 50.0) & (x.flow["angle"] == 0.0) & (x.χ == 0.5)));
+realisation = subset(full_comp_angle_flow_data, :lw_config => ByRow(x -> (x.sensing["range"] .== 50.0) & (x.flow["angle"] == 0.0) & (x.χ == 0.2)));
 ideal_config = realisation.lw_config[1];
 ideal_positions = readdlm(joinpath(ideal_config.save_dir, ideal_config.save_name * ".tsv"));
 ideal_positions[ideal_positions.==""] .= 0;
@@ -101,7 +101,7 @@ sample = 1:sample_size
 size_pt = 390 .* (1, 0.75)
 fig = Figure(resolution=size_pt)
 ax1 = CairoMakie.Axis(
-    fig[1, 1]; title="Less Compensating, Some Navigation", subtitle=L"$\chi = 0.5, \kappa_1 = \kappa_2 = 1$, Ideal (yellow), $\chi=0$, Ideal(blue)"
+    fig[1, 1]; title="Slightly Compensating, Good Navigation", subtitle="χ = $(ideal_config.χ), $(ideal_config.heading_perception["type"]) (yellow), χ=$(config.χ), $(config.heading_perception["type"]) (blue)"
 )
 for i in 1:5:minimum(hcat(length(ideal_y_pos[:, 1]), length(y_pos[:, 1])))
     scatter!(
@@ -138,4 +138,4 @@ hidespines!(ax1)
 ax1.aspect = DataAspect()
 
 fig
-save(String(plotsdir("test", "scatter_traj_intended_χ=0.5.png")), fig)
+save(String(plotsdir("test", "scatter_traj_perc=$(ideal_config.heading_perception["type"])_χ=$(ideal_config.χ).png")), fig)

--- a/scripts/workflow_v2.jl
+++ b/scripts/workflow_v2.jl
@@ -158,4 +158,3 @@ fig, ax, hm = @pipe df |>
                     get_centile_arrival(_; centile=50) |>
                     make_failures_explicit(_, df, [:sensing_range, :flow_strength]) |>
                     plot_arrival_heatmap(_; save_plot=true)
-

--- a/src/CollectiveMigration/src/utils.jl
+++ b/src/CollectiveMigration/src/utils.jl
@@ -79,6 +79,7 @@ function decompress_data(compressed_df::DataFrame; show_progress::Bool=true)::Da
         else
             flow_angle = nothing
         end
+        comp = row.lw_config.χ
         goal_tol = row.lw_config.goal["tolerance"]
         num_agents = row.lw_config.num_agents
 
@@ -90,7 +91,7 @@ function decompress_data(compressed_df::DataFrame; show_progress::Bool=true)::Da
             num_agents=fill(num_agents, size(row.df)[1]),
             sensing_type=fill(sensing_type, size(row.df)[1]),
             heading_perception=fill(heading_perception, size(row.df)[1]),
-        )
+            χ=fill(comp, size(row.df)[1]),)
         temp = hcat(row.df, realisation_config)
         if i == 1
             df = temp

--- a/src/CollectiveNavigation.jl
+++ b/src/CollectiveNavigation.jl
@@ -4,7 +4,8 @@ using DrWatson
 using Reexport
 @reexport using DataFrames
 @reexport using CollectiveMigration
-export run_experiment, run_experiment_one_param, run_experiment_flow_angle
+export run_experiment, run_experiment_one_param, run_experiment_flow_angle,
+    run_experiment_flow_comp
 include("running_experiments.jl")
 
 end

--- a/src/running_experiments.jl
+++ b/src/running_experiments.jl
@@ -4,11 +4,14 @@ DrWatson.allaccess(::SimulationConfig) = [
     "flow",
     "heading_perception",
     "num_repeats",
-    "mean_run_time",
+    # "mean_run_time",
     "num_agents",
     "terminal_time",
     "goal",
-    "initial_condition",
+    # "initial_condition",
+    "χ",
+    "κ_1",
+    "κ_2"
 ]
 DrWatson.default_expand(::SimulationConfig) =
     ["sensing", "flow", "goal", "initial_condition", "heading_perception"]
@@ -113,8 +116,11 @@ function run_experiment_flow_angle(
         flow_dict["angle"] = angle_value
         setproperty!(config, :flow, flow_dict)
         # safe save not necessary as realisations are averaged over
+        # Need an ugly adjustment to catch old filenames,
+        # i.e. containing initial_condition and mean_run_time, no chi or kappa.
+
         data, file = produce_or_load(
-            String(datadir("realisation_data_angle")),
+            String(datadir("realisation_data_comp")),
             config,
             run_many_realisations;
             verbose=true

--- a/src/running_experiments.jl
+++ b/src/running_experiments.jl
@@ -173,4 +173,5 @@ function run_experiment_flow_comp(
             end
         end
     end
+    return df
 end


### PR DESCRIPTION
This PR aims to address #1. It does this by splitting the active swimming velocity ($v$) into $v^1,v^2$ where $v^1$ is the active swimming velocity dedicated to swimming in the goal direction, $\varphi$, and $v^2$ is the portion of active swimming velocity dedicated to compensating for the flow. The full model is thus

$\frac{\mathrm{d}x_i(t)}{\mathrm{d}t} = (1-\chi)v^1_{i}(t) + \chi v^2_i(t) + u(x_i(t),t) $

where $\chi$ is a parameter controlling the amount of effort dedicated to compensating for the flow. In practice, the velocity $v$ was chosen using a random sample from a von Mises distribution with mean $\varphi$, concentration $\kappa$. Should it now be:
1. a sample from $vM\left((1-\chi)\varphi+\chi\zeta, \kappa\right)$ where $\zeta$ is the flow direction? 
1. The weighted sum of two samples, one from $vM(\varphi,\kappa_1)$, one from $vM(\zeta,\kappa_2)$ where $\kappa_1$ is the confidence in the goal direction, and $\kappa_2$ is confidence in the flow direction. 

> In the case $\kappa_1=\kappa_2$, are these equivalent? No, see [Directional Statistics, Mardia & Jupp](http://palaeo.spb.ru/pmlibrary/pmbooks/mardia&jupp_2000.pdf), pg. 44. The sum of two von Mises random variables is not von Mises, but can be approximated as follows:
> Let $\theta_1, \theta_2$ be independently distributed as $vM(\mu_1,\kappa_1), vM(\mu_2,\kappa_2)$ then the pdf of $\theta = \theta_1+\theta_2$ is
> 
> $h(\theta) = \frac{1}{2\pi I_0(\kappa_1)I_0(\kappa_2)} I_0\left(\sqrt{\kappa_1^2+\kappa_2^2 + 2 \kappa_1 \kappa_2 \cos{(\theta-[\mu_1+\mu_2])}}\right).$
> This can be approximated using the wrapped Normal distribution as 
> 
> $\theta_1+\theta_2 \sim vM(\mu_1+\mu_2, A^{-1}(A(\kappa_1)A(\kappa_2))$
> 
> where $A(\cdot) = \frac{I_1(\kappa)}{I_0(\kappa)}$.

Doing so adds another complexity to communication: whereas previously an individual could only communicate their intended heading ( $\arg(v)$ ) or actual heading ( $\arg(v+u)$ ), now it is possible to communicate any of the following.
1. Goal/intended direction ( $\arg{(v^1)}$ )
1. Compensated swimming direction ( $\arg{(v^1+v^2)}$ )
1. Actual direction ( $\arg{(v^1+v^2+u)}$ )

If we utilise 1. above, we will sample $\arg(v^1+v^2)$, and won't know the contributions from $\arg(v^1)$ or $\arg(v^2)$ separately. This adds a complication in how we communicate, as it assumes the animal cannot separate the two sources of information. This is another benefit to implementing 2. 


To amend the code to account for these changes, we must
- [x] Adjust the individual's movement to include drift compensation via 2. above
    - [x] Add in function to get flow angle from flow (trivial for laminar flow)
- [x] Adjust the communication mechanism, adding in a new option for ~~'compensated'~~  _ideal_ direction i.e. where an individual would aim if there was no flow
~~- [ ] Adjust `savename` to include a $\chi=$`chi` parameter, as well as the 'compensated' option~~
    ~~- This is the main issue as `produce_or_load` from DrWatson.jl doesn't play well with changing the `savename`.  Options here: a) look into `collect_results!` or other functions that play nicer with new parameters. b) leave `savename` as is for backwards compatibility, develop new way to load and save new simulations. c) Modify `savename`, don't try and load old simulations on this branch, don't merge into main. d) Write new function that considers old forms of `savename`. e) Rename all old data files with new `savename`~~

In the long term, e) is preferable, rather than messing around with hacky `savename` edits. For now, we will go with c) and keep the branches separate. 

The main changes will happen in `dynamics.jl` with adjustments to `savename` in `running_experiments.jl`. **Of key importance is to ensure backwards compatibility with previous simulation data and save names**